### PR TITLE
chore: update company name references

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2023 Horizon Blockchain Games Inc.
+Copyright 2023 Sequence Platforms ULC Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2023 Sequence Platforms ULC Inc.
+Copyright 2023 Sequence Platforms ULC
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "ethers",
     "ethers.js"
   ],
-  "author": "Horizon Blockchain Games Inc.",
+  "author": "Sequence Platforms ULC Inc.",
   "license": "Apache-2.0",
   "devDependencies": {
     "@0xsequence/auth": "^2.2.11",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "ethers",
     "ethers.js"
   ],
-  "author": "Sequence Platforms ULC Inc.",
+  "author": "Sequence Platforms ULC",
   "license": "Apache-2.0",
   "devDependencies": {
     "@0xsequence/auth": "^2.2.11",


### PR DESCRIPTION
Automated cleanup of legacy company name references:

- "Horizon Blockchain Games" → "Sequence Platforms ULC"
- "Sequence Platforms Inc." → "Sequence Platforms ULC"
- "Horizon" → "Sequence"

Scope: README / LICENSE / package.json files (excluding vendor/).